### PR TITLE
#36: Allowed AddAutoMapper to be called multiple times per process safely

### DIFF
--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AppDomainResolutionTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AppDomainResolutionTests.cs
@@ -26,6 +26,20 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         }
 
         [Fact]
+        public void ShouldRegisterConfigurationAsSingleton()
+        {
+            using (var scope = _provider.CreateScope())
+            {
+                var first = _provider.GetService<IConfigurationProvider>();
+                var second = _provider.GetService<IConfigurationProvider>();
+                var third = scope.ServiceProvider.GetService<IConfigurationProvider>();
+
+                first.ShouldBeSameAs(second);
+                first.ShouldBeSameAs(third);
+            }
+        }
+        
+        [Fact]
         public void ShouldConfigureProfiles()
         {
             _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(2);
@@ -38,9 +52,18 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         }
 
         [Fact]
-        public void ShouldInitializeStatically()
+        public void ShouldRegisterMapperAsScoped()
         {
-            _provider.GetService<IConfigurationProvider>().ShouldBeSameAs(Mapper.Configuration);
+            using (var outerScope = _provider.CreateScope())
+            using (var innerScope = outerScope.ServiceProvider.CreateScope())
+            {
+                var first = outerScope.ServiceProvider.GetService<IMapper>();
+                var second = outerScope.ServiceProvider.GetService<IMapper>();
+                var third = innerScope.ServiceProvider.GetService<IMapper>();
+
+                first.ShouldBeSameAs(second);
+                first.ShouldNotBeSameAs(third);
+            }
         }
     }
 }

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AssemblyResolutionTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AssemblyResolutionTests.cs
@@ -26,6 +26,20 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         }
 
         [Fact]
+        public void ShouldRegisterConfigurationAsSingleton()
+        {
+            using (var scope = _provider.CreateScope())
+            {
+                var first = _provider.GetService<IConfigurationProvider>();
+                var second = _provider.GetService<IConfigurationProvider>();
+                var third = scope.ServiceProvider.GetService<IConfigurationProvider>();
+
+                first.ShouldBeSameAs(second);
+                first.ShouldBeSameAs(third);
+            }
+        }
+
+        [Fact]
         public void ShouldConfigureProfiles()
         {
             _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(2);
@@ -38,9 +52,18 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         }
 
         [Fact]
-        public void ShouldInitializeStatically()
+        public void ShouldRegisterMapperAsScoped()
         {
-            _provider.GetService<IConfigurationProvider>().ShouldBeSameAs(Mapper.Configuration);
+            using (var outerScope = _provider.CreateScope())
+            using (var innerScope = outerScope.ServiceProvider.CreateScope())
+            {
+                var first = outerScope.ServiceProvider.GetService<IMapper>();
+                var second = outerScope.ServiceProvider.GetService<IMapper>();
+                var third = innerScope.ServiceProvider.GetService<IMapper>();
+
+                first.ShouldBeSameAs(second);
+                first.ShouldNotBeSameAs(third);
+            }
         }
     }
 }

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/TypeResolutionTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/TypeResolutionTests.cs
@@ -24,6 +24,20 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         }
 
         [Fact]
+        public void ShouldRegisterConfigurationAsSingleton()
+        {
+            using (var scope = _provider.CreateScope())
+            {
+                var first = _provider.GetService<IConfigurationProvider>();
+                var second = _provider.GetService<IConfigurationProvider>();
+                var third = scope.ServiceProvider.GetService<IConfigurationProvider>();
+
+                first.ShouldBeSameAs(second);
+                first.ShouldBeSameAs(third);
+            }
+        }
+
+        [Fact]
         public void ShouldConfigureProfiles()
         {
             _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(2);
@@ -33,6 +47,21 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         public void ShouldResolveMapper()
         {
             _provider.GetService<IMapper>().ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void ShouldRegisterMapperAsScoped()
+        {
+            using (var outerScope = _provider.CreateScope())
+            using (var innerScope = outerScope.ServiceProvider.CreateScope())
+            {
+                var first = outerScope.ServiceProvider.GetService<IMapper>();
+                var second = outerScope.ServiceProvider.GetService<IMapper>();
+                var third = innerScope.ServiceProvider.GetService<IMapper>();
+
+                first.ShouldBeSameAs(second);
+                first.ShouldNotBeSameAs(third);
+            }
         }
 
         [Fact]
@@ -57,24 +86,6 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         public void ShouldResolveTypeConverter()
         {
             _provider.GetService<FooTypeConverter>().ShouldNotBeNull();
-        }
-    }
-
-    public class TypeResolutionTests_ForStaticConfig
-    {
-        private readonly IServiceProvider _provider;
-
-        public TypeResolutionTests_ForStaticConfig()
-        {
-            IServiceCollection services = new ServiceCollection();
-            services.AddAutoMapper(typeof(Source));
-            _provider = services.BuildServiceProvider();
-        }
-
-        [Fact]
-        public void ShouldInitializeStatically()
-        {
-            _provider.GetService<IConfigurationProvider>().ShouldBeSameAs(Mapper.Configuration);
         }
     }
 }


### PR DESCRIPTION
The difference from the previous implementation is that the static `Mapper` is now not initialised so you can't do `Mapper.Map` from anywhere you want, but the whole point of registering with DI in the first place is that you want to inject the `IMapper` instead of using statics isn't it?

I think that, semantically, a call to `AddAutoMapper` should just be registering the appropriate classes with DI, given that it'd be called from `Startup.ConfigureServices` and works on an `IServiceCollection`. I wouldn't expect that to configure static classes, which are kind of the antithesis to DI.