### PR TITLE
Potential optimization

### DIFF
--- a/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -74,8 +74,9 @@
                 .SelectMany(a => a.DefinedTypes)
                 .ToArray();
 
+            var profileTypeInfo = typeof(Profile).GetTypeInfo();
             var profiles = allTypes
-                .Where(t => typeof(Profile).GetTypeInfo().IsAssignableFrom(t) && !t.IsAbstract)
+                .Where(t => profileTypeInfo.IsAssignableFrom(t) && !t.IsAbstract)
                 .ToArray();
 
             void ConfigAction(IServiceProvider serviceProvider, IMapperConfigurationExpression cfg)


### PR DESCRIPTION
Been trying to read up on .NET Core's reflection, but it's not 100% clear if `GetTypeInfo()` is expensive or not. Just noticed it was being calculated for every type found in the assembly, so might be worth it?
https://blogs.msdn.microsoft.com/dotnet/2016/02/10/porting-to-net-core/