### PR TITLE
Possibility to inject service into Automapper Profile is added.

### DIFF
--- a/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -85,7 +85,8 @@
 
                 foreach (var profile in profiles.Select(t => t.AsType()))
                 {
-                    cfg.AddProfile(profile);
+                    var profileInstance = ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, profile) as Profile;
+                    cfg.AddProfile(profileInstance);
                 }
             }
 

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AppDomainResolutionTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AppDomainResolutionTests.cs
@@ -16,6 +16,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         {
             IServiceCollection services = new ServiceCollection();
             services.AddAutoMapper();
+            services.AddTransient<ISomeService>(sp => new FooService(5));
             _provider = services.BuildServiceProvider();
         }
 
@@ -28,7 +29,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         [Fact]
         public void ShouldConfigureProfiles()
         {
-            _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(2);
+            _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(3);
         }
 
         [Fact]

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AssemblyResolutionTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AssemblyResolutionTests.cs
@@ -20,6 +20,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         {
             IServiceCollection services = new ServiceCollection();
             services.AddAutoMapper(typeof(Source).GetTypeInfo().Assembly);
+            services.AddTransient<ISomeService>(sp => new FooService(5));
             var serviceProvider = services.BuildServiceProvider();
             return serviceProvider;
         }
@@ -33,7 +34,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         [Fact]
         public void ShouldConfigureProfiles()
         {
-            _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(2);
+            _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(3);
         }
 
         [Fact]

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/DependencyTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/DependencyTests.cs
@@ -25,5 +25,14 @@
 
             dest.ResolvedValue.ShouldBe(5);
         }
+        
+        [Fact]
+        public void ShouldResolveWithDependencyInjectedInProfileConstructor()
+        {
+            var mapper = _provider.GetService<IMapper>();
+            var dest = mapper.Map<Source3, Dest3>(new Source3());
+
+            dest.ResolvedValue.ShouldBe(15);
+        }
     }
 }

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/Profiles.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/Profiles.cs
@@ -18,6 +18,15 @@
     {
         public int ResolvedValue { get; set; }
     }
+    
+    public class Source3
+    {
+    }
+
+    public class Dest3
+    {
+        public int ResolvedValue { get; set; }
+    }
 
     public class Profile1 : Profile
     {
@@ -35,6 +44,15 @@
         {
             CreateMap<Source2, Dest2>()
                 .ForMember(d => d.ResolvedValue, opt => opt.ResolveUsing<DependencyResolver>());
+        }
+    }
+    
+    internal class Profile3 : Profile
+    {
+        public Profile3(ISomeService someService)
+        {
+            CreateMap<Source3, Dest3>()
+                .ForMember(d => d.ResolvedValue, opt => opt.ResolveUsing(src => someService.Modify(10)));
         }
     }
 

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/RegistrationTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/RegistrationTests.cs
@@ -13,6 +13,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         {
             IServiceCollection services = new ServiceCollection();
             services.AddAutoMapper();
+            services.AddTransient<ISomeService>(sp => new FooService(5));
 
             var serviceProvider = services.BuildServiceProvider();
 

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/TypeResolutionTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/TypeResolutionTests.cs
@@ -14,6 +14,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         {
             IServiceCollection services = new ServiceCollection();
             services.AddAutoMapper(typeof(Source));
+            services.AddTransient<ISomeService>(sp => new FooService(5));
             _provider = services.BuildServiceProvider();
         }
 
@@ -26,7 +27,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         [Fact]
         public void ShouldConfigureProfiles()
         {
-            _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(2);
+            _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(3);
         }
 
         [Fact]


### PR DESCRIPTION
This request is added possibility to inject services into the Automapper profiles.

I know there are `IValueResolver` exist but they are depended on resolution environment such as types of source and destination, that makes them not reusable for other cases when types are differ.
