### PR TITLE
Enhancement #96 adds some ability to specify the service lifetime of the IMapper interface

### DIFF
--- a/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -8,16 +8,18 @@ namespace AutoMapper
     using System.Reflection;
     using Microsoft.Extensions.DependencyInjection;
 
-    /// <summary>
-    /// Extensions to scan for AutoMapper classes and register the configuration, mapping, and extensions with the service collection
-    /// - Finds <see cref="Profile"/> classes and initializes a new <see cref="MapperConfiguration" />
-    /// - Scans for <see cref="ITypeConverter{TSource,TDestination}"/>, <see cref="IValueResolver{TSource,TDestination,TDestMember}"/>, <see cref="IMemberValueResolver{TSource,TDestination,TSourceMember,TDestMember}" /> and <see cref="IMappingAction{TSource,TDestination}"/> implementations and registers them as <see cref="ServiceLifetime.Transient"/>
-    /// - Registers <see cref="IConfigurationProvider"/> as <see cref="ServiceLifetime.Singleton"/>
-    /// - Registers <see cref="IMapper"/> as <see cref="ServiceLifetime.Scoped"/> with a service factory of the scoped <see cref="IServiceProvider"/>
-    /// After calling AddAutoMapper you can resolve an <see cref="IMapper" /> instance from a scoped service provider, or as a dependency
-    /// To use <see cref="QueryableExtensions.Extensions.ProjectTo{TDestination}(IQueryable,IConfigurationProvider, System.Linq.Expressions.Expression{System.Func{TDestination, object}}[])" /> you can resolve the <see cref="IConfigurationProvider"/> instance directly for from an <see cref="IMapper" /> instance.
-    /// </summary>
-    public static class ServiceCollectionExtensions
+	/// <summary>
+	/// Extensions to scan for AutoMapper classes and register the configuration, mapping, and extensions with the service collection:
+	/// <list type="bullet">
+	/// <item> Finds <see cref="Profile"/> classes and initializes a new <see cref="MapperConfiguration" />,</item> 
+	/// <item> Scans for <see cref="ITypeConverter{TSource,TDestination}"/>, <see cref="IValueResolver{TSource,TDestination,TDestMember}"/>, <see cref="IMemberValueResolver{TSource,TDestination,TSourceMember,TDestMember}" /> and <see cref="IMappingAction{TSource,TDestination}"/> implementations and registers them as <see cref="ServiceLifetime.Transient"/>, </item>
+	/// <item> Registers <see cref="IConfigurationProvider"/> as <see cref="ServiceLifetime.Singleton"/>, and</item>
+	/// <item> Registers <see cref="IMapper"/> as a configurable <see cref="ServiceLifetime"/> (default is <see cref="ServiceLifetime.Transient"/>)</item>
+	/// </list>
+	/// After calling AddAutoMapper you can resolve an <see cref="IMapper" /> instance from a scoped service provider, or as a dependency
+	/// To use <see cref="QueryableExtensions.Extensions.ProjectTo{TDestination}(IQueryable,IConfigurationProvider, System.Linq.Expressions.Expression{System.Func{TDestination, object}}[])" /> you can resolve the <see cref="IConfigurationProvider"/> instance directly for from an <see cref="IMapper" /> instance.
+	/// </summary>
+	public static class ServiceCollectionExtensions
     {
         private const string ObsoleteNoAssemblies = "This overload is error prone and it will be removed. Please pass the assemblies to scan explicitly. You can use AppDomain.CurrentDomain.GetAssemblies() if that works for you.";
 

--- a/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -42,13 +42,13 @@ namespace AutoMapper
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, params Assembly[] assemblies)
             => AddAutoMapperClasses(services, configAction, assemblies);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
             => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies, serviceLifetime);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped) 
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime = ServiceLifetime.Transient) 
             => AddAutoMapperClasses(services, configAction, assemblies, serviceLifetime);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
             => AddAutoMapperClasses(services, null, assemblies, serviceLifetime);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, params Type[] profileAssemblyMarkerTypes)
@@ -61,15 +61,15 @@ namespace AutoMapper
             => AddAutoMapperClasses(services, configAction, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly));
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, 
-            IEnumerable<Type> profileAssemblyMarkerTypes, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+            IEnumerable<Type> profileAssemblyMarkerTypes, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
             => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), serviceLifetime);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, 
-            IEnumerable<Type> profileAssemblyMarkerTypes, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+            IEnumerable<Type> profileAssemblyMarkerTypes, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
             => AddAutoMapperClasses(services, configAction, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), serviceLifetime);
 
         private static IServiceCollection AddAutoMapperClasses(IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, 
-            IEnumerable<Assembly> assembliesToScan, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+            IEnumerable<Assembly> assembliesToScan, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
         {
             // Just return if we've already added AutoMapper to avoid double-registration
             if (services.Any(sd => sd.ServiceType == typeof(IMapper)))

--- a/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -115,23 +115,8 @@ namespace AutoMapper
             }
 
             services.AddSingleton<IConfigurationProvider>(sp => new MapperConfiguration(cfg => ConfigAction(sp, cfg)));
-            switch (serviceLifetime)
-            {
-                case ServiceLifetime.Singleton:
-                    services.TryAddSingleton<IMapper>(sp =>
-                        new Mapper(sp.GetRequiredService<IConfigurationProvider>(), sp.GetService));
-                    break;
-                case ServiceLifetime.Scoped:
-                    services.TryAddScoped<IMapper>(sp =>
-                        new Mapper(sp.GetRequiredService<IConfigurationProvider>(), sp.GetService));
-                    break;
-                case ServiceLifetime.Transient:
-                    services.TryAddTransient<IMapper>(sp =>
-                        new Mapper(sp.GetRequiredService<IConfigurationProvider>(), sp.GetService));
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(serviceLifetime), serviceLifetime, "Unrecognized Service Lifetime.");
-            }
+            services.Add(new ServiceDescriptor(typeof(IMapper),
+	            sp => new Mapper(sp.GetRequiredService<IConfigurationProvider>()), serviceLifetime));
 
             return services;
         }

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests.csproj
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests.csproj
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/Integrations/ServiceLifetimeTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/Integrations/ServiceLifetimeTests.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests.Integrations
+{
+	public class ServiceLifetimeTests
+	{
+		internal interface ISingletonService
+		{
+			Bar DoTheThing(Foo theObj);
+		}
+
+		internal class TestSingletonService : ISingletonService
+		{
+			private readonly IMapper _mapper;
+
+			public TestSingletonService(IMapper mapper)
+			{
+				_mapper = mapper;
+			}
+
+			public Bar DoTheThing(Foo theObj)
+			{
+				var bar = _mapper.Map<Bar>(theObj);
+				return bar;
+			}
+		}
+
+		internal class Foo
+		{
+			public int TheValue { get; set; }
+		}
+
+		internal class Bar
+		{
+			public int TheValue { get; set; }
+		}
+
+
+		[Fact]
+		public void CanUseDefaultInjectedIMapperInSingletonService()
+		{
+			//arrange
+			var services = new ServiceCollection();
+			services.TryAddSingleton(p =>
+			{
+				var config =
+					new MapperConfiguration(mc => { mc.CreateMap<Foo, Bar>().ReverseMap(); });
+				return config;
+			});
+			services.TryAddSingleton<ISingletonService, TestSingletonService>();
+			services.AddAutoMapper(GetType().Assembly);
+			var sp = services.BuildServiceProvider();
+			Bar actual;
+
+			//act
+			using (var scope = sp.CreateScope())
+			{
+				var service = scope.ServiceProvider.GetService<ISingletonService>();
+				actual = service.DoTheThing(new Foo{TheValue = 1});
+			}
+
+			//assert
+			actual.ShouldNotBeNull();
+			actual.TheValue.ShouldBe(1);
+		}
+	}
+}

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/ServiceLifetimeTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/ServiceLifetimeTests.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
 using Shouldly;
 using Xunit;
 

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/ServiceLifetimeTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/ServiceLifetimeTests.cs
@@ -1,0 +1,318 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
+{
+	public class ServiceLifetimeTests
+	{
+		//Implicitly Scoped
+		[Fact]
+		public void AddAutoMapperExtensionDefaultWithAssemblySingleDelegateArgCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper(cfg => { }, new List<Assembly>());
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionDefaultWithAssemblyDoubleDelegateArgCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper((sp, cfg) => { }, new List<Assembly>());
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionDefaultWithAssemblyCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper(new List<Assembly>());
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionDefaultSingleDelegateWithProfileTypeCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper(cfg => { },new[] {typeof(ServiceLifetimeTests)});
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionDefaultDoubleDelegateWithProfileTypeCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper((sp, cfg) => { },new[] {typeof(ServiceLifetimeTests)});
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+		}
+
+		//Explicitly Singleton
+		[Fact]
+		public void AddAutoMapperExtensionSingletonWithAssemblySingleDelegateArgCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper(cfg => { }, new List<Assembly>(), ServiceLifetime.Singleton);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Singleton);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionSingletonWithAssemblyDoubleDelegateArgCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper((sp, cfg) => { }, new List<Assembly>(), ServiceLifetime.Singleton);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Singleton);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionSingletonWithAssemblyCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper(new List<Assembly>(), ServiceLifetime.Singleton);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Singleton);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionSingletonSingleDelegateWithProfileTypeCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper(cfg => { },new[] {typeof(ServiceLifetimeTests)}, ServiceLifetime.Singleton);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Singleton);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionSingletonDoubleDelegateWithProfileTypeCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper((sp, cfg) => { },new[] {typeof(ServiceLifetimeTests)}, ServiceLifetime.Singleton);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Singleton);
+		}
+
+		//Explicitly Transient
+		[Fact]
+		public void AddAutoMapperExtensionTransientWithAssemblySingleDelegateArgCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper(cfg => { }, new List<Assembly>(), ServiceLifetime.Transient);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Transient);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionTransientWithAssemblyDoubleDelegateArgCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper((sp, cfg) => { }, new List<Assembly>(), ServiceLifetime.Transient);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Transient);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionTransientWithAssemblyCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper(new List<Assembly>(), ServiceLifetime.Transient);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Transient);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionTransientSingleDelegateWithProfileTypeCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper(cfg => { },new[] {typeof(ServiceLifetimeTests)}, ServiceLifetime.Transient);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Transient);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionTransientDoubleDelegateWithProfileTypeCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper((sp, cfg) => { },new[] {typeof(ServiceLifetimeTests)}, ServiceLifetime.Transient);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Transient);
+		}
+
+		//Explicitly Scoped
+		[Fact]
+		public void AddAutoMapperExtensionScopedWithAssemblySingleDelegateArgCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper(cfg => { }, new List<Assembly>(), ServiceLifetime.Scoped);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionScopedWithAssemblyDoubleDelegateArgCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper((sp, cfg) => { }, new List<Assembly>(), ServiceLifetime.Scoped);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionScopedWithAssemblyCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper(new List<Assembly>(), ServiceLifetime.Scoped);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionScopedSingleDelegateWithProfileTypeCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper(cfg => { },new[] {typeof(ServiceLifetimeTests)}, ServiceLifetime.Scoped);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+		}
+
+		[Fact]
+		public void AddAutoMapperExtensionScopedDoubleDelegateWithProfileTypeCollection()
+		{
+			//arrange
+			var serviceCollection = new ServiceCollection();
+
+			//act
+			serviceCollection.AddAutoMapper((sp, cfg) => { },new[] {typeof(ServiceLifetimeTests)}, ServiceLifetime.Scoped);
+			var serviceDescriptor = serviceCollection.FirstOrDefault(sd => sd.ServiceType == typeof(IMapper));
+
+			//assert
+			serviceDescriptor.ShouldNotBeNull();
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+		}
+
+	}
+}

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/ServiceLifetimeTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/ServiceLifetimeTests.cs
@@ -9,7 +9,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
 {
 	public class ServiceLifetimeTests
 	{
-		//Implicitly Scoped
+		//Implicitly Transient
 		[Fact]
 		public void AddAutoMapperExtensionDefaultWithAssemblySingleDelegateArgCollection()
 		{
@@ -22,7 +22,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
 
 			//assert
 			serviceDescriptor.ShouldNotBeNull();
-			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Transient);
 		}
 
 		[Fact]
@@ -37,7 +37,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
 
 			//assert
 			serviceDescriptor.ShouldNotBeNull();
-			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Transient);
 		}
 
 		[Fact]
@@ -52,7 +52,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
 
 			//assert
 			serviceDescriptor.ShouldNotBeNull();
-			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Transient);
 		}
 
 		[Fact]
@@ -67,7 +67,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
 
 			//assert
 			serviceDescriptor.ShouldNotBeNull();
-			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Transient);
 		}
 
 		[Fact]
@@ -82,7 +82,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
 
 			//assert
 			serviceDescriptor.ShouldNotBeNull();
-			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+			serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Transient);
 		}
 
 		//Explicitly Singleton


### PR DESCRIPTION
per some extended discussion, for all to review.  Default service lifetime is still scoped.  I only added it to extension methods that did not have a `params` argument to preserve backward compatibility.