### PR TITLE
Tests showing how bad singleton is

### DIFF
--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/Profiles.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/Profiles.cs
@@ -72,6 +72,13 @@
         int Modify(int value);
     }
 
+    public class MutableService : ISomeService
+    {
+        public int Value { get; set; }
+
+        public int Modify(int value) => value + Value;
+    }
+
     public class FooService : ISomeService
     {
         private readonly int _value;

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/ScopeTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/ScopeTests.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
+{
+    public class ScopeTests
+    {
+        [Fact]
+        public void Can_depend_on_scoped_services_as_transient_default()
+        {
+            var services = new ServiceCollection();
+            services.AddAutoMapper(new [] { typeof(Source).Assembly });
+            services.AddScoped<ISomeService, MutableService>();
+
+            var provider = services.BuildServiceProvider();
+
+            using (var scope = provider.CreateScope())
+            {
+                var mutableService = (MutableService)scope.ServiceProvider.GetService<ISomeService>();
+                mutableService.Value = 10;
+
+                var mapper = scope.ServiceProvider.GetService<IMapper>();
+
+                var dest = mapper.Map<Dest2>(new Source2 {ConvertedValue = 5});
+
+                dest.ConvertedValue.ShouldBe(15);
+            }
+        }
+
+        [Fact]
+        public void Can_depend_on_scoped_services_as_scoped()
+        {
+            var services = new ServiceCollection();
+            services.AddAutoMapper(new [] { typeof(Source).Assembly }, ServiceLifetime.Scoped);
+            services.AddScoped<ISomeService, MutableService>();
+
+            var provider = services.BuildServiceProvider();
+
+            using (var scope = provider.CreateScope())
+            {
+                var mutableService = (MutableService)scope.ServiceProvider.GetService<ISomeService>();
+                mutableService.Value = 10;
+
+                var mapper = scope.ServiceProvider.GetService<IMapper>();
+
+                var dest = mapper.Map<Dest2>(new Source2 {ConvertedValue = 5});
+
+                dest.ConvertedValue.ShouldBe(15);
+            }
+        }
+
+        [Fact]
+        public void Cannot_correctly_resolve_scoped_services_as_singleton()
+        {
+            var services = new ServiceCollection();
+            services.AddAutoMapper(new [] { typeof(Source).Assembly }, ServiceLifetime.Singleton);
+            services.AddScoped<ISomeService, MutableService>();
+
+            var provider = services.BuildServiceProvider();
+
+            using (var scope = provider.CreateScope())
+            {
+                var mutableService = (MutableService)scope.ServiceProvider.GetService<ISomeService>();
+                mutableService.Value = 10;
+
+                var mapper = scope.ServiceProvider.GetService<IMapper>();
+
+                var dest = mapper.Map<Dest2>(new Source2 {ConvertedValue = 5});
+
+                dest.ConvertedValue.ShouldBe(5);
+            }
+        }
+    }
+}


### PR DESCRIPTION
In the first two tests, the services are correctly resolved.

In the third test, one of the dependencies is scoped, and you silently get a different instance than was originally resolved. The scoped instance is *different* than the one used by the `IMapper` instance.
