### PR TITLE
Add Extension Method Option To Assert Valid Configuration

### DIFF
--- a/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -8,56 +8,100 @@ namespace AutoMapper
     using System.Reflection;
     using Microsoft.Extensions.DependencyInjection;
 
-	/// <summary>
-	/// Extensions to scan for AutoMapper classes and register the configuration, mapping, and extensions with the service collection:
-	/// <list type="bullet">
-	/// <item> Finds <see cref="Profile"/> classes and initializes a new <see cref="MapperConfiguration" />,</item> 
-	/// <item> Scans for <see cref="ITypeConverter{TSource,TDestination}"/>, <see cref="IValueResolver{TSource,TDestination,TDestMember}"/>, <see cref="IMemberValueResolver{TSource,TDestination,TSourceMember,TDestMember}" /> and <see cref="IMappingAction{TSource,TDestination}"/> implementations and registers them as <see cref="ServiceLifetime.Transient"/>, </item>
-	/// <item> Registers <see cref="IConfigurationProvider"/> as <see cref="ServiceLifetime.Singleton"/>, and</item>
-	/// <item> Registers <see cref="IMapper"/> as a configurable <see cref="ServiceLifetime"/> (default is <see cref="ServiceLifetime.Transient"/>)</item>
-	/// </list>
-	/// After calling AddAutoMapper you can resolve an <see cref="IMapper" /> instance from a scoped service provider, or as a dependency
-	/// To use <see cref="QueryableExtensions.Extensions.ProjectTo{TDestination}(IQueryable,IConfigurationProvider, System.Linq.Expressions.Expression{System.Func{TDestination, object}}[])" /> you can resolve the <see cref="IConfigurationProvider"/> instance directly for from an <see cref="IMapper" /> instance.
-	/// </summary>
-	public static class ServiceCollectionExtensions
+    /// <summary>
+    /// Extensions to scan for AutoMapper classes and register the configuration, mapping, and extensions with the service collection:
+    /// <list type="bullet">
+    /// <item> Finds <see cref="Profile"/> classes and initializes a new <see cref="MapperConfiguration" />,</item> 
+    /// <item> Scans for <see cref="ITypeConverter{TSource,TDestination}"/>, <see cref="IValueResolver{TSource,TDestination,TDestMember}"/>, <see cref="IMemberValueResolver{TSource,TDestination,TSourceMember,TDestMember}" /> and <see cref="IMappingAction{TSource,TDestination}"/> implementations and registers them as <see cref="ServiceLifetime.Transient"/>, </item>
+    /// <item> Registers <see cref="IConfigurationProvider"/> as <see cref="ServiceLifetime.Singleton"/>, and</item>
+    /// <item> Registers <see cref="IMapper"/> as a configurable <see cref="ServiceLifetime"/> (default is <see cref="ServiceLifetime.Transient"/>)</item>
+    /// </list>
+    /// After calling AddAutoMapper you can resolve an <see cref="IMapper" /> instance from a scoped service provider, or as a dependency
+    /// To use <see cref="QueryableExtensions.Extensions.ProjectTo{TDestination}(IQueryable,IConfigurationProvider, System.Linq.Expressions.Expression{System.Func{TDestination, object}}[])" /> you can resolve the <see cref="IConfigurationProvider"/> instance directly for from an <see cref="IMapper" /> instance.
+    /// </summary>
+    public static class ServiceCollectionExtensions
     {
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, params Assembly[] assemblies)
             => AddAutoMapperClasses(services, null, assemblies);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, params Assembly[] assemblies) 
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, bool validate, params Assembly[] assemblies)
+            => AddAutoMapperClasses(services, null, assemblies, validate: validate);
+
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, params Assembly[] assemblies)
             => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies);
+
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, bool validate, params Assembly[] assemblies)
+            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies, validate: validate);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, params Assembly[] assemblies)
             => AddAutoMapperClasses(services, configAction, assemblies);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
-            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies, serviceLifetime);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, bool validate, params Assembly[] assemblies)
+            => AddAutoMapperClasses(services, configAction, assemblies, validate: validate);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime = ServiceLifetime.Transient) 
-            => AddAutoMapperClasses(services, configAction, assemblies, serviceLifetime);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies)
+            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
-            => AddAutoMapperClasses(services, null, assemblies, serviceLifetime);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime, bool validate = false)
+            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies, serviceLifetime, validate);
+
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, bool validate)
+            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies, validate: validate);
+
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies)
+            => AddAutoMapperClasses(services, configAction, assemblies);
+
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime, bool validate = false)
+            => AddAutoMapperClasses(services, configAction, assemblies, serviceLifetime, validate);
+
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, bool validate)
+            => AddAutoMapperClasses(services, configAction, assemblies, validate: validate);
+
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, IEnumerable<Assembly> assemblies)
+            => AddAutoMapperClasses(services, null, assemblies);
+
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime, bool validate = false)
+            => AddAutoMapperClasses(services, null, assemblies, serviceLifetime, validate);
+
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, IEnumerable<Assembly> assemblies, bool validate)
+            => AddAutoMapperClasses(services, null, assemblies, validate: validate);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, params Type[] profileAssemblyMarkerTypes)
             => AddAutoMapperClasses(services, null, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly));
 
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, bool validate, params Type[] profileAssemblyMarkerTypes)
+            => AddAutoMapperClasses(services, null, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), validate: validate);
+
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, params Type[] profileAssemblyMarkerTypes)
             => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly));
+
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, bool validate, params Type[] profileAssemblyMarkerTypes)
+            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), validate: validate);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, params Type[] profileAssemblyMarkerTypes)
             => AddAutoMapperClasses(services, configAction, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly));
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, 
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, bool validate, params Type[] profileAssemblyMarkerTypes)
+            => AddAutoMapperClasses(services, configAction, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), validate: validate);
+
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction,
             IEnumerable<Type> profileAssemblyMarkerTypes, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
             => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), serviceLifetime);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, 
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction,
+            IEnumerable<Type> profileAssemblyMarkerTypes, ServiceLifetime serviceLifetime, bool validate = false)
+            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), serviceLifetime, validate);
+
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction,
             IEnumerable<Type> profileAssemblyMarkerTypes, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
             => AddAutoMapperClasses(services, configAction, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), serviceLifetime);
 
-        private static IServiceCollection AddAutoMapperClasses(IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, 
-            IEnumerable<Assembly> assembliesToScan, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction,
+            IEnumerable<Type> profileAssemblyMarkerTypes, bool validate)
+            => AddAutoMapperClasses(services, configAction, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), validate: validate);
+
+        private static IServiceCollection AddAutoMapperClasses(IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction,
+            IEnumerable<Assembly> assembliesToScan, ServiceLifetime serviceLifetime = ServiceLifetime.Transient, bool validate = false)
         {
             // Just return if we've already added AutoMapper to avoid double-registration
             if (services.Any(sd => sd.ServiceType == typeof(IMapper)))
@@ -87,16 +131,24 @@ namespace AutoMapper
                 typeof(IMappingAction<,>)
             };
             foreach (var type in openTypes.SelectMany(openType => allTypes
-                .Where(t => t.IsClass 
-                    && !t.IsAbstract 
+                .Where(t => t.IsClass
+                    && !t.IsAbstract
                     && t.AsType().ImplementsGenericInterface(openType))))
             {
                 services.AddTransient(type.AsType());
             }
 
-            services.AddSingleton<IConfigurationProvider>(sp => new MapperConfiguration(cfg => ConfigAction(sp, cfg)));
+            services.AddSingleton<IConfigurationProvider>(sp =>
+            {
+                var configuration = new MapperConfiguration(cfg => ConfigAction(sp, cfg));
+                if (validate)
+                {
+                    configuration.AssertConfigurationIsValid();
+                }
+                return configuration;
+            });
             services.Add(new ServiceDescriptor(typeof(IMapper),
-	            sp => new Mapper(sp.GetRequiredService<IConfigurationProvider>(), sp.GetService), serviceLifetime));
+                sp => new Mapper(sp.GetRequiredService<IConfigurationProvider>(), sp.GetService), serviceLifetime));
 
             return services;
         }

--- a/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -23,6 +23,8 @@ namespace AutoMapper
     {
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, params Assembly[] assemblies)
             => AddAutoMapperClasses(services, null, assemblies);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction)
+            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), Enumerable.Empty<Assembly>());
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, bool assertConfigurationIsValid, params Assembly[] assemblies)
             => AddAutoMapperClasses(services, null, assemblies, assertConfigurationIsValid: assertConfigurationIsValid);

--- a/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -24,84 +24,84 @@ namespace AutoMapper
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, params Assembly[] assemblies)
             => AddAutoMapperClasses(services, null, assemblies);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, bool validate, params Assembly[] assemblies)
-            => AddAutoMapperClasses(services, null, assemblies, validate: validate);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, bool assertConfigurationIsValid, params Assembly[] assemblies)
+            => AddAutoMapperClasses(services, null, assemblies, assertConfigurationIsValid: assertConfigurationIsValid);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, params Assembly[] assemblies)
             => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, bool validate, params Assembly[] assemblies)
-            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies, validate: validate);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, bool assertConfigurationIsValid, params Assembly[] assemblies)
+            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies, assertConfigurationIsValid: assertConfigurationIsValid);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, params Assembly[] assemblies)
             => AddAutoMapperClasses(services, configAction, assemblies);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, bool validate, params Assembly[] assemblies)
-            => AddAutoMapperClasses(services, configAction, assemblies, validate: validate);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, bool assertConfigurationIsValid, params Assembly[] assemblies)
+            => AddAutoMapperClasses(services, configAction, assemblies, assertConfigurationIsValid: assertConfigurationIsValid);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies)
             => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime, bool validate = false)
-            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies, serviceLifetime, validate);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime, bool assertConfigurationIsValid = false)
+            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies, serviceLifetime, assertConfigurationIsValid);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, bool validate)
-            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies, validate: validate);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, bool assertConfigurationIsValid)
+            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), assemblies, assertConfigurationIsValid: assertConfigurationIsValid);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies)
             => AddAutoMapperClasses(services, configAction, assemblies);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime, bool validate = false)
-            => AddAutoMapperClasses(services, configAction, assemblies, serviceLifetime, validate);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime, bool assertConfigurationIsValid = false)
+            => AddAutoMapperClasses(services, configAction, assemblies, serviceLifetime, assertConfigurationIsValid);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, bool validate)
-            => AddAutoMapperClasses(services, configAction, assemblies, validate: validate);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, IEnumerable<Assembly> assemblies, bool assertConfigurationIsValid)
+            => AddAutoMapperClasses(services, configAction, assemblies, assertConfigurationIsValid: assertConfigurationIsValid);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, IEnumerable<Assembly> assemblies)
             => AddAutoMapperClasses(services, null, assemblies);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime, bool validate = false)
-            => AddAutoMapperClasses(services, null, assemblies, serviceLifetime, validate);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, IEnumerable<Assembly> assemblies, ServiceLifetime serviceLifetime, bool assertConfigurationIsValid = false)
+            => AddAutoMapperClasses(services, null, assemblies, serviceLifetime, assertConfigurationIsValid);
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, IEnumerable<Assembly> assemblies, bool validate)
-            => AddAutoMapperClasses(services, null, assemblies, validate: validate);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, IEnumerable<Assembly> assemblies, bool assertConfigurationIsValid)
+            => AddAutoMapperClasses(services, null, assemblies, assertConfigurationIsValid: assertConfigurationIsValid);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, params Type[] profileAssemblyMarkerTypes)
             => AddAutoMapperClasses(services, null, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly));
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, bool validate, params Type[] profileAssemblyMarkerTypes)
-            => AddAutoMapperClasses(services, null, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), validate: validate);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, bool assertConfigurationIsValid, params Type[] profileAssemblyMarkerTypes)
+            => AddAutoMapperClasses(services, null, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), assertConfigurationIsValid: assertConfigurationIsValid);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, params Type[] profileAssemblyMarkerTypes)
             => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly));
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, bool validate, params Type[] profileAssemblyMarkerTypes)
-            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), validate: validate);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction, bool assertConfigurationIsValid, params Type[] profileAssemblyMarkerTypes)
+            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), assertConfigurationIsValid: assertConfigurationIsValid);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, params Type[] profileAssemblyMarkerTypes)
             => AddAutoMapperClasses(services, configAction, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly));
 
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, bool validate, params Type[] profileAssemblyMarkerTypes)
-            => AddAutoMapperClasses(services, configAction, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), validate: validate);
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction, bool assertConfigurationIsValid, params Type[] profileAssemblyMarkerTypes)
+            => AddAutoMapperClasses(services, configAction, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), assertConfigurationIsValid: assertConfigurationIsValid);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction,
             IEnumerable<Type> profileAssemblyMarkerTypes, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
             => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), serviceLifetime);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction,
-            IEnumerable<Type> profileAssemblyMarkerTypes, ServiceLifetime serviceLifetime, bool validate = false)
-            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), serviceLifetime, validate);
+            IEnumerable<Type> profileAssemblyMarkerTypes, ServiceLifetime serviceLifetime, bool assertConfigurationIsValid = false)
+            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), serviceLifetime, assertConfigurationIsValid);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction,
             IEnumerable<Type> profileAssemblyMarkerTypes, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
             => AddAutoMapperClasses(services, configAction, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), serviceLifetime);
 
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction,
-            IEnumerable<Type> profileAssemblyMarkerTypes, bool validate)
-            => AddAutoMapperClasses(services, configAction, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), validate: validate);
+            IEnumerable<Type> profileAssemblyMarkerTypes, bool assertConfigurationIsValid)
+            => AddAutoMapperClasses(services, configAction, profileAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), assertConfigurationIsValid: assertConfigurationIsValid);
 
         private static IServiceCollection AddAutoMapperClasses(IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction,
-            IEnumerable<Assembly> assembliesToScan, ServiceLifetime serviceLifetime = ServiceLifetime.Transient, bool validate = false)
+            IEnumerable<Assembly> assembliesToScan, ServiceLifetime serviceLifetime = ServiceLifetime.Transient, bool assertConfigurationIsValid = false)
         {
             // Just return if we've already added AutoMapper to avoid double-registration
             if (services.Any(sd => sd.ServiceType == typeof(IMapper)))
@@ -141,7 +141,7 @@ namespace AutoMapper
             services.AddSingleton<IConfigurationProvider>(sp =>
             {
                 var configuration = new MapperConfiguration(cfg => ConfigAction(sp, cfg));
-                if (validate)
+                if (assertConfigurationIsValid)
                 {
                     configuration.AssertConfigurationIsValid();
                 }

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AppDomainResolutionTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AppDomainResolutionTests.cs
@@ -28,7 +28,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         [Fact]
         public void ShouldConfigureProfiles()
         {
-            _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(3);
+            _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(4);
         }
 
         [Fact]

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AssemblyResolutionTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/AssemblyResolutionTests.cs
@@ -13,7 +13,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
 
         static AssemblyResolutionTests()
         {
-            _provider = BuildServiceProvider();    
+            _provider = BuildServiceProvider();
         }
 
         private static ServiceProvider BuildServiceProvider()
@@ -33,7 +33,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         [Fact]
         public void ShouldConfigureProfiles()
         {
-            _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(3);
+            _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(4);
         }
 
         [Fact]

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/DependencyTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/DependencyTests.cs
@@ -13,7 +13,9 @@
         {
             IServiceCollection services = new ServiceCollection();
             services.AddTransient<ISomeService>(sp => new FooService(5));
-            services.AddAutoMapper(typeof(Source), typeof(Profile));
+            services.AddSingleton<DependencyResolver>();
+            services.AddSingleton<DependencyValueConverter>();
+            services.AddAutoMapper(cfg => cfg.AddProfile<Profile2>());
             _provider = services.BuildServiceProvider();
 
             _provider.GetService<IConfigurationProvider>().AssertConfigurationIsValid();
@@ -32,7 +34,7 @@
         public void ShouldConvertWithDependency()
         {
             var mapper = _provider.GetService<IMapper>();
-            var dest = mapper.Map<Source2, Dest2>(new Source2 { ConvertedValue = 5});
+            var dest = mapper.Map<Source2, Dest2>(new Source2 { ConvertedValue = 5 });
 
             dest.ConvertedValue.ShouldBe(10);
         }

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/Profiles.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/Profiles.cs
@@ -2,12 +2,12 @@
 {
     public class Source
     {
-        
+
     }
 
     public class Dest
     {
-        
+
     }
 
     public class Source2
@@ -96,7 +96,7 @@
         public void Process(object source, object destination, ResolutionContext context) { }
     }
 
-    internal class FooValueResolver: IValueResolver<object, object, object>
+    internal class FooValueResolver : IValueResolver<object, object, object>
     {
         public object Resolve(object source, object destination, object destMember, ResolutionContext context)
         {
@@ -135,4 +135,25 @@
         public int Convert(int sourceMember, ResolutionContext context)
             => _service.Modify(sourceMember);
     }
+
+    #region Validate Test Profile
+    class InvalidProfile : Profile
+    {
+        public InvalidProfile()
+        {
+            // PropertyTwo is unmapped, profile is invalid
+            CreateMap<SourceInvalid, DestinationInvalid>();
+        }
+    }
+
+    class SourceInvalid
+    {
+        public string PropertyOne { get; set; }
+    }
+
+    class DestinationInvalid
+    {
+        public string PropertyTwo { get; set; }
+    }
+    #endregion
 }

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/TypeResolutionTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/TypeResolutionTests.cs
@@ -26,7 +26,7 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         [Fact]
         public void ShouldConfigureProfiles()
         {
-            _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(3);
+            _provider.GetService<IConfigurationProvider>().GetAllTypeMaps().Length.ShouldBe(4);
         }
 
         [Fact]

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/ValidateTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/ValidateTests.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+using Xunit;
+
+namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
+{
+    public class ValidateTests
+    {
+        [Fact]
+        public void ShouldFailAssertForInvalidProfile()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+
+            // Act
+            serviceCollection.AddAutoMapper(true, typeof(InvalidProfile));
+
+            // Assert
+            var provider = serviceCollection.BuildServiceProvider();
+            Assert.Throws<AutoMapperConfigurationException>(() => provider.GetRequiredService<IMapper>());
+        }
+
+        class InvalidProfile : Profile
+        {
+            public InvalidProfile()
+            {
+                // PropertyTwo is unmapped, profile is invalid
+                CreateMap<Source, Destination>();
+            }
+        }
+
+        class Source
+        {
+            public string PropertyOne { get; set; }
+        }
+
+        class Destination
+        {
+            public string PropertyTwo { get; set; }
+        }
+    }
+}

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/ValidateTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/ValidateTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using System.Reflection;
 using Xunit;
 
 namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
@@ -18,25 +17,6 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
             // Assert
             var provider = serviceCollection.BuildServiceProvider();
             Assert.Throws<AutoMapperConfigurationException>(() => provider.GetRequiredService<IMapper>());
-        }
-
-        class InvalidProfile : Profile
-        {
-            public InvalidProfile()
-            {
-                // PropertyTwo is unmapped, profile is invalid
-                CreateMap<Source, Destination>();
-            }
-        }
-
-        class Source
-        {
-            public string PropertyOne { get; set; }
-        }
-
-        class Destination
-        {
-            public string PropertyTwo { get; set; }
         }
     }
 }


### PR DESCRIPTION
This PR adds an additional argument to the suite of `AddAutoMapper` methods allowing users to specify that configurations should be validated via `AssertConfigurationIsValid` on the first injection of IMapper.