### PR TITLE
Missing extension

### DIFF
--- a/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,13 +1,13 @@
 ﻿namespace AutoMapper
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
     using AutoMapper.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Options;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
 
     /// <summary>
     /// Extensions to scan for AutoMapper classes and register the configuration, mapping, and extensions with the service collection:
@@ -25,6 +25,9 @@
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IMapperConfigurationExpression> configAction)
             => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(cfg), null);
 
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, Action<IServiceProvider, IMapperConfigurationExpression> configAction)
+            => AddAutoMapperClasses(services, (sp, cfg) => configAction?.Invoke(sp, cfg), null);
+        
         public static IServiceCollection AddAutoMapper(this IServiceCollection services, params Assembly[] assemblies)
             => AddAutoMapperClasses(services, null, assemblies);
 

--- a/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,13 +1,13 @@
 ﻿namespace AutoMapper
 {
-    using AutoMapper.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.DependencyInjection.Extensions;
-    using Microsoft.Extensions.Options;
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using AutoMapper.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Extensions.Options;
 
     /// <summary>
     /// Extensions to scan for AutoMapper classes and register the configuration, mapping, and extensions with the service collection:

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/MultipleRegistrationTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/MultipleRegistrationTests.cs
@@ -1,6 +1,7 @@
-﻿using System.Linq;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
+using System;
+using System.Linq;
 using Xunit;
 
 namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
@@ -10,11 +11,28 @@ namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests
         [Fact]
         public void Can_register_multiple_times()
         {
+            static void registration(IServiceCollection services)
+                => services.AddAutoMapper(cfg => { });
+
+            AutoMapperShouldBeRegistrableMultipleTimesUsing(registration);
+        }
+
+        [Fact]
+        public void Can_register_multiple_times_using_service_provider()
+        {
+            static void registration(IServiceCollection services)
+                => services.AddAutoMapper((cfg, sp) => { });
+
+            AutoMapperShouldBeRegistrableMultipleTimesUsing(registration);
+        }
+
+        private void AutoMapperShouldBeRegistrableMultipleTimesUsing(Action<IServiceCollection> registration)
+        {
             var services = new ServiceCollection();
 
-            services.AddAutoMapper(cfg => { });
-            services.AddAutoMapper(cfg => { });
-            services.AddAutoMapper(cfg => { });
+            registration(services);
+            registration(services);
+            registration(services);
 
             var serviceProvider = services.BuildServiceProvider();
 

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/MultipleRegistrationTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/MultipleRegistrationTests.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Shouldly;
-using System;
+﻿using System;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
 using Xunit;
 
 namespace AutoMapper.Extensions.Microsoft.DependencyInjection.Tests


### PR DESCRIPTION
There is an overload of AddAutoMapper using a configurationAction with an IMapperConfiguration argument, but no overload using a configurationAction with an IServiceProvider argument.

Doing 
```csharp
services.AddAutoMapper((sp, cfg) => {...});
```
will currently result in a compiler error as there are two overloads with a second _params_ argument. You would have to do something like 
```csharp
services.AddAutoMapper((sp, cfg) => {...}, Array.Empty<Type>());
```
which isn't pretty intuitive.