### PR TITLE
Downgrade Microsoft.Extensions.Options to 3.0.0

### DIFF
--- a/src/AutoMapper.Extensions.Microsoft.DependencyInjection/AutoMapper.Extensions.Microsoft.DependencyInjection.csproj
+++ b/src/AutoMapper.Extensions.Microsoft.DependencyInjection/AutoMapper.Extensions.Microsoft.DependencyInjection.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="11.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
I added the latest AutoMapper.Extensions.Microsoft.DependencyInjection to a .NET 5 project and it pulled in .NET 6 dependencies.  Downgrading Microsoft.Extensions.Options to 3.0.0 (based on the minimum .NET Core version supporting .NET Standard 2.1) might fix this, but in all honesty I'm not sure what repercussions this has.

If I change the unit test project to .NET 5.0 the tests all pass, but I don't have .NET 6 on my machine to run the TestApp.