### PR TITLE
Set assembliesToScanArray to Distinct assemblies

### DIFF
--- a/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -69,7 +69,7 @@
                     .Configure<IServiceProvider>((options, sp) => configAction(sp, options));
             }
 
-            var assembliesToScanArray = assembliesToScan as Assembly[] ?? assembliesToScan?.ToArray();
+            var assembliesToScanArray = (assembliesToScan as Assembly[] ?? assembliesToScan)?.Distinct().ToArray();
 
             if (assembliesToScanArray != null && assembliesToScanArray.Length > 0)
             {


### PR DESCRIPTION
If multiple types with the same assembly are sent in via on of the `AddAutoMapper` calls that use `profileAssemblyMarkerTypes` (or if duplicate assemblies are just passed in), then any Profiles in those assemblies end up being duplicated in the MapperConfiguration options, which can cause a lot of inconsistent behavior.

Initially, this was discovered via the exception thrown in  `TypeMap.CheckDifferent(TypePair types)` when using Profiles that contain maps with `IncludeAllDerived()` set. If the assembly contains more than one `Profile` class, then the maps with `IncludeAllDerived` set are duplicated, and that `CheckDifferent` validation throws at runtime.

This change accounts for this accidental duplication of assemblies during configuration by explicitly setting `assembliesToScanArray` to distinct assemblies.

